### PR TITLE
Remove -unit from write_stream

### DIFF
--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -490,8 +490,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
             " ".join(gds_files)
         )
 
-        # TODO: explanation for why we chose this unit parameter
-        self.verbose_append("write_stream -mode ALL -unit 1000 {map_file} {merge_options} {gds}".format(
+        self.verbose_append("write_stream -mode ALL {map_file} {merge_options} {gds}".format(
             map_file=map_file,
             merge_options=merge_options,
             gds=self.output_gds_filename


### PR DESCRIPTION
According to the `write_stream` command, this specifies resolution for values in the GDS. If not specified, it defaults to the units specified in the technology's LEF. ASAP7's libraries have 4000 by default, so it was wrong to have this fixed at 1000.