### PR TITLE
No special cells

### DIFF
--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -320,10 +320,6 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
     def place_tap_cells(self) -> bool:
         tap_cell = self.technology.get_special_cell_by_type(CellType.TapCell)
 
-        if tap_cell == None:
-            self.logger.warning("Tap cells are not defined in the tech plugin and will not be added. This should be overridden with a user hook.")
-            return True
-
         if len(tap_cell) == 0:
             self.logger.warning("Tap cells are improperly defined in the tech plugin and will not be added. This step should be overridden with a user hook.")
             return True
@@ -451,10 +447,6 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
     def add_fillers(self) -> bool:
         """add filler cells"""
         stdfiller = self.technology.get_special_cell_by_type(CellType.StdFiller)
-
-        if stdfiller == None:
-            self.logger.warning("Standard filler cells are not defined in the tech plugin. Filler cells will not be added.")
-            return True
 
         if len(stdfiller) == 0:
             self.logger.warning(

--- a/synthesis/genus/__init__.py
+++ b/synthesis/genus/__init__.py
@@ -272,10 +272,6 @@ class Genus(HammerSynthesisTool, CadenceTool):
         tie_hi_cell = self.technology.get_special_cell_by_type(CellType.TieHiCell)
         tie_lo_cell = self.technology.get_special_cell_by_type(CellType.TieLoCell)
 
-        if tie_hi_cell == None or tie_lo_cell == None:
-            self.logger.warning("Tie Cells are not defined in the tech plugin. Tieoffs will not be added during synthesis.")
-            return True
-
         if len(tie_hi_cell) != 1 or len (tie_lo_cell) != 1:
             self.logger.warning("Hi and Lo tiecells are unspecified or improperly specified and will not be added during synthesis.")
             return True


### PR DESCRIPTION
Companion PR to Hammer PR.  This makes the tool compatible with not defining special cells in the tech plugin, since the user may want to completely override all of the special cells calls and not have to define them in the tech plugin.