### PR TITLE
Fix reading post-synth SDC before hierarchical PAR clock-tree

### DIFF
--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -497,10 +497,8 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         if self.hierarchical_mode.is_nonleaf_hierarchical():
             self.verbose_append('''
             flatten_ilm
-            set_interactive_constraint_modes [all_constraint_modes]
-            source clock_constraints_fragment.sdc
-            source pin_constraints_fragment.sdc
-            ''', clean=True)
+            update_constraint_mode -name my_constraint_mode -ilm_sdc_files {sdc}
+            '''.format(sdc=self.post_synth_sdc), clean=True)
         if len(self.get_clock_ports()) > 0:
             # Ignore clock tree when there are no clocks
             self.verbose_append("create_clock_tree_spec")


### PR DESCRIPTION
For some reason, the contents of the constraints aren't available at this point when running hierarchically. 
In a leaf module, the `init_design` step causes Innovus to read the SDCs defined in `read_mmmc`, while in a non-leaf module, it does not. The documentation does not make it clear why this is the case.

The previous solution re-sourced the hammer-generated SDCs, but this does not reflect path groups created during clock-gating during synthesis. An alternative solution is to also interactively re-source the `.mapped.sdc` at this point, but I encountered syntax errors when trying that. The generated SDC could not be read in by Innovus for some reason?

The new solution is to update the default `my_constraint_mode` with the same post-synth SDC it should have read at the beginning. This seems to force it to read the SDC file.

Its possible this isn't the ideal place to solve this issue. Since place_opt_design does timing-driven placement, it may be preferred to make sure the SDC has been processed before the place_design step, rather than the clock_tree step?

