### PR TITLE
Dedup modules for hierarchical sim

### DIFF
--- a/common/tool.py
+++ b/common/tool.py
@@ -307,6 +307,7 @@ if {{ {get_db_str} ne "" }} {{
             child_modules = list(next(d for i,d in enumerate(self.get_setting("vlsi.inputs.hierarchical.manual_modules")) if self.top_module in d).values())[0]
 
             # Get all paths to the child module instances
+            # For P&R, this only works in the flattened ILM state
             return '''
             set child_modules_ir "./find_child_modules.json"
             set child_modules_ir [open $child_modules_ir "w"]
@@ -317,7 +318,7 @@ if {{ {get_db_str} ne "" }} {{
 
             for {{set i 0}} {{$i < $numcells}} {{incr i}} {{
                 set cell [lindex $cells $i]
-                set inst_paths [get_db [get_db insts -if {{.base_cell==base_cell:$cell}}] .name]
+                set inst_paths [get_db [get_db modules -if {{.name==$cell}}] .hinsts.name]
                 set inst_paths [join $inst_paths "\\", \\""]
                 if {{$i == $numcells - 1}} {{
                     puts $child_modules_ir "    \\"$cell\\": \\[\\"$inst_paths\\"\\]"

--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -61,7 +61,8 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
                 ILMStruct(dir=self.ilm_dir_name, data_dir=ilm_data_dir, module=self.top_module,
                           lef=os.path.join(self.run_dir, "{top}ILM.lef".format(top=self.top_module)),
                           gds=self.output_gds_filename,
-                          netlist=self.output_netlist_filename)
+                          netlist=self.output_netlist_filename,
+                          sim_netlist=self.output_sim_netlist_filename)
             ]
         else:
             self.output_ilms = []
@@ -690,8 +691,8 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
     def write_regs(self) -> bool:
         """write regs info to be read in for simulation register forcing"""
         if self.hierarchical_mode.is_nonleaf_hierarchical():
-            self.append(self.child_modules_tcl())
             self.append('flatten_ilm')
+            self.append(self.child_modules_tcl())
         self.append(self.write_regs_tcl())
         self.ran_write_regs = True
         return True

--- a/synthesis/genus/__init__.py
+++ b/synthesis/genus/__init__.py
@@ -276,6 +276,9 @@ class Genus(HammerSynthesisTool, CadenceTool):
 
     def syn_map(self) -> bool:
         self.verbose_append("syn_map")
+        # Need to suffix modules for hierarchical simulation if not top
+        if self.hierarchical_mode not in [HierarchicalMode.Flat, HierarchicalMode.Top]:
+            self.verbose_append("update_names -module -log hier_updated_names.log -suffix _{MODULE}".format(MODULE=self.top_module))
         return True
 
     def add_tieoffs(self) -> bool:


### PR DESCRIPTION
Generated modules (e.g. clock gaters) as well as common modules with different implementations (e.g. an FPU in a Rocket vs. BOOM core) will clash if not deduped in hierarchical simulation. This PR resolves this issue by modifying the module definitions to deduplicate them.

- Reverts #61. Instead, appends a suffix for all modules in synthesis for non-top hierarchical modules.
- Fixes child module paths (common b/w syn & par)
- Depends on ucb-bar/hammer#605