### PR TITLE
Unflatten ILM when leaving write_regs.

### DIFF
--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -694,6 +694,8 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
             self.append('flatten_ilm')
             self.append(self.child_modules_tcl())
         self.append(self.write_regs_tcl())
+        if self.hierarchical_mode.is_nonleaf_hierarchical():
+            self.append('unflatten_ilm')
         self.ran_write_regs = True
         return True
 


### PR DESCRIPTION
ILM should be in the flattened state for write_netlist to work correctly