### PR TITLE
Early rail analysis

### DIFF
--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -514,7 +514,7 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         # TODO generate power data from synthesis or static power
         self.verbose_append("set_power_data -format area -bias_voltage {voltage} -power {power}".format(
             voltage=str(VoltageValue(self.get_setting("vlsi.inputs.supplies.VDD")).value_in_units("V")),
-            power=self.get_setting("par.rail_analysis_power")))
+            power=self.get_setting("par.innovus.rail_analysis_power")))
 
         corners = self.get_mmmc_corners()
         era_options = ["-method", "era_static",

--- a/par/innovus/defaults.yml
+++ b/par/innovus/defaults.yml
@@ -33,3 +33,7 @@ par.innovus:
   # Note that this requires an optional licence (enccco).
   # type: bool
   use_cco: true
+
+  # Estimated power for early rail analysis.
+  # This shall be estimated for the typical supply given in vlsi.inputs.supplies.VDD in units of Watts
+  rail_analysis_power: 1


### PR DESCRIPTION
Implements early rail analysis after `place_opt_design`. Key differences to rail analysis in the Voltus plugin is:

- Early static rail analysis does not require a separate license, and it can be done in Innovus without any technology libraries. The accuracy is also *very coarse*.
- Distributes the power given by `par.rail_analysis_power` (see ucb-bar/hammer#611) over all the placed instances, given the power routing. In my opinion, this is better than running static power analysis since it allows the user to do a coarse what-if analysis using a different power number.
- `open_chip` script loads newest rail analysis database (in the case of multiple MMMC corners, this will be the last corner) and prompts the user for whether they want to display the results in the GUI. If so, this is what shows up using the `TinyRocketConfig` example from the Chipyard ASAP7 example (obviously, the results don't make sense since the SRAMs aren't characterized):

![era](https://user-images.githubusercontent.com/11860787/126881612-79bc6496-b18f-4b95-99e4-72d92e719e38.png)
