### PR TITLE
power_straps_widths_and_spacings cannot be empty…

### DIFF
--- a/utils/innovus/dump_stackup_to_json.tcl
+++ b/utils/innovus/dump_stackup_to_json.tcl
@@ -34,8 +34,12 @@ foreach layer [get_db layers] {
         # For now take the last one, since that appears to have correct data for colored metals
         set spacing_table [lrange [lindex [lindex $spacing_table 0] end] 2 end]
         set widths_and_spacings {}
-        foreach line $spacing_table {
-            lappend widths_and_spacings "\{\"width_at_least\": [lindex $line 1], \"min_spacing\": [lindex $line end]\}"
+        if { [llength $spacing_table] == 0} {
+            lappend widths_and_spacings "\{\"width_at_least\": 0.0, \"min_spacing\": $min_spacing\}"
+        } else {
+            foreach line $spacing_table {
+                lappend widths_and_spacings "\{\"width_at_least\": [lindex $line 1], \"min_spacing\": [lindex $line end]\}"
+            }
         }
         set output "        \{"
         append output "\"name\": \"$name\", "


### PR DESCRIPTION
Update stackup dumper to set it to `{"width_at_least": 0.0, "min_spacing": $min_spacing}` if the spacing table not provided for any given layer. Otherwise, Hammer's power strap calculations will have an index out of bounds error.