### PR TITLE
Support FSDB & SHM Waveforms

### DIFF
--- a/power/voltus/__init__.py
+++ b/power/voltus/__init__.py
@@ -374,9 +374,9 @@ class Voltus(HammerPowerTool, CadenceTool):
                             self.logger.error("Must specify Spice model files in tech plugin to generate macro PG libraries")
                             return True
                         else:
-                            options.extend(["-spice_models", " ".join(spice_models)])
+                            options.extend(["-spice_models", "{", " ".join(spice_models), "}"])
                             if len(spice_corners) > 0:
-                                options.extend(["-spice_corners", "{", "} {".join(spice_corners), "}"])
+                                options.extend(["-spice_corners", "{{", "} {".join(spice_corners), "}}"])
                         m_output.append("set_pg_library_mode {}".format(" ".join(options)))
                         m_output.append("write_pg_library -out_dir {}".format(os.path.join(self.macro_lib_dir, corner.name)))
 


### PR DESCRIPTION
ucb-bar/chipyard#1072 and ucb-bar/chipyard#1102 added FSDB support in Chipyard because newer VCS versions now require FSDB output.

This PR selects the waveform format based on the extension. Now, the supported formats are VCD/VPD, FSDB, and SHM (default output of Xcelium).

Includes small bugfixes for PG view generation.