### PR TITLE
Allow express mode to run routing

### DIFF
--- a/par/innovus/__init__.py
+++ b/par/innovus/__init__.py
@@ -582,6 +582,12 @@ class Innovus(HammerPlaceAndRouteTool, CadenceTool):
         """Route the design."""
         if self.hierarchical_mode.is_nonleaf_hierarchical():
             self.verbose_append("flatten_ilm")
+
+        # Allow express design effort to complete running.
+        # By default, route_design will abort in express mode with
+        # "WARNING (NRIG-142) Express flow by default will not run routing".
+        self.verbose_append("set_db design_express_route true")
+
         self.verbose_append("route_design")
         return True
 


### PR DESCRIPTION
Otherwise the flow aborts at route_design with the following error:

```
@file 176: route_design
% Begin route_design (date=08/22 22:48:02, mem=4059.8M)
route_design: cpu time = 00:00:00, elapsed time = 00:00:00, memory = 4059.82 (MB), peak = 4845.68 (MB)
AE_INFO: Pre Route call back at the beginning of routeDesign
**INFO: setDesignMode -flowEffort express
**INFO: setDesignMode -powerEffort none
WARNING (NRIG-142) Express flow by default will not run routing. To run express routing, please set setDesignmode design_express_route true.
route_design: cpu time = 00:00:00, elapsed time = 00:00:00, memory = 4059.84 (MB), peak = 4845.68 (MB)
% End route_design (date=08/22 22:48:02, total cpu=0:00:00.1, real=0:00:00.0, peak res=4059.8M, current mem=4059.8M)
**ERROR: (IMPSE-110):    File '.../par_rundir/par.tcl' line 176: errors out.
```